### PR TITLE
Schema select button intercepts bug

### DIFF
--- a/src/base.coffee
+++ b/src/base.coffee
@@ -394,7 +394,6 @@ class TreemaNode
       @select()
       @removeSelectedNodes()
       e.preventDefault()
-      console.log e
     return if editing
     e.preventDefault()
     @removeSelectedNodes()


### PR DESCRIPTION
I found the backspace deleting bug. It is due to using @removeSelectedNodes() twice in base.coffee after removing a node. Link to issue https://github.com/codecombat/treema/issues/6
Can you please check the patch and give feedback.
